### PR TITLE
Add Stage 8 depth layer colour detection to VisionProcessor

### DIFF
--- a/include/Types.hpp
+++ b/include/Types.hpp
@@ -33,7 +33,12 @@ enum class SafetyState {
     EXCESSIVE_SPEED,
 
     /** Marker rotation falls outside the configured angular range. */
-    INVALID_ORIENTATION
+    INVALID_ORIENTATION,
+
+    DEPTH_EXCEEDED, ///< The forbidden playdough layer colour was detected
+                    ///< within the ROI, indicating the tool has penetrated
+                    ///< beyond the permitted depth. Triggers an immediate
+                    ///< FREEZE_NOW event and retract command via RobotInterlock.
 };
 
 /**

--- a/include/VisionConfig.hpp
+++ b/include/VisionConfig.hpp
@@ -124,4 +124,79 @@ struct VisionConfig {
      * Change here to switch dictionary without modifying VisionProcessor.
      */
     int dictionaryId = cv::aruco::DICT_6X6_250;
+
+    // Depth layer colour detection 
+    //
+    // The forbidden layer is a specific playdough colour (e.g. red) placed
+    // beneath the permitted cutting layers. When this colour becomes visible
+    // inside the ROI the tool has exceeded its permitted depth and the robot
+    // must freeze and retract immediately.
+    //
+    // HSV is used in preference to BGR because it separates colour (hue)
+    // from brightness (value), making detection robust under variable
+    // lighting conditions — critical for a physical hardware demo under
+    // lab fluorescent lighting.
+    //
+    // OpenCV HSV channel ranges:
+    //   H (hue):        0 – 179   (half of the 360° colour wheel)
+    //   S (saturation): 0 – 255
+    //   V (value):      0 – 255
+    //
+    // Red requires two hue ranges because it wraps around 0° / 180°:
+    //   Range 1 (lower red): H = 0  – 10
+    //   Range 2 (upper red): H = 160 – 179
+    // For non-wrapping colours (blue, green, yellow) only range 1 is
+    // needed — set depthHueLower2 > depthHueUpper2 to produce an empty
+    // mask2 so the bitwise_or in Stage 8 reduces to mask1 alone.
+    
+    int depthHueLower1 = 0;     ///< Lower hue bound for range 1.
+                                ///< For red: 0. Adjust for other colours.
+    
+    int depthHueUpper1 = 10;    ///< Upper hue bound for range 1.
+                                ///< For red: 10. Adjust for other colours.
+    
+    int depthHueLower2 = 160;   ///< Lower hue bound for range 2.
+                                ///< For red: 160. Set > depthHueUpper2 to
+                                ///< disable range 2 for non-wrapping colours.
+    
+    int depthHueUpper2 = 179;   ///< Upper hue bound for range 2.
+                                ///< For red: 179.
+    
+    int depthSatMin = 100;      ///< Minimum saturation threshold.
+                                ///< Filters washed-out or near-grey pixels
+                                ///< that share the target hue by coincidence.
+    
+    int depthSatMax = 255;      ///< Maximum saturation threshold.
+    
+    int depthValMin = 50;       ///< Minimum value (brightness) threshold.
+                                ///< Filters very dark pixels that appear
+                                ///< to match the hue under shadow conditions.
+    
+    int depthValMax = 255;      ///< Maximum value threshold.
+    
+    /**
+     * @brief Minimum number of HSV-matching pixels required to confirm
+     *        the forbidden layer is exposed.
+     *
+     * Acts as a noise gate - isolated reflections, stray colour patches,
+     * or single-pixel sensor noise will not trigger a freeze. If false
+     * positives occur during testing, increase this value. If the system
+     * is slow to detect a genuine exposure, decrease it.
+     *
+     * Recommended starting point: 500 pixels at 640x480 resolution.
+     */
+    int depthPixelThreshold = 500;
+    
+    /**
+     * @brief Runtime enable/disable flag for Stage 8 colour detection.
+     *
+     * Allows the depth check to be toggled from the UI without
+     * recompiling. Satisfies the brief requirement for mouse-adjustable
+     * parameters and supports testing of the remaining pipeline stages
+     * in isolation.
+     *
+     * true  = Stage 8 active (default, production behaviour).
+     * false = Stage 8 bypassed (testing / calibration mode).
+     */
+    bool depthCheckEnabled = true;
 };

--- a/src/VisionProcessor.cpp
+++ b/src/VisionProcessor.cpp
@@ -13,6 +13,7 @@
 
 #include "VisionProcessor.hpp"
 #include <cmath>
+#include <opencv2/imgproc.hpp>
 
 // Constructor
 
@@ -208,6 +209,122 @@ SafetyResult VisionProcessor::process(
         if (angleDeg < config_.orientationMin || angleDeg > config_.orientationMax) {
             hasPrevious_ = false;
             return makeResult(SafetyState::INVALID_ORIENTATION);
+        }
+    }
+    
+    // Stage 8: Depth layer colour detection
+    //
+    // Detects whether the forbidden playdough layer colour is visible anywhere
+    // inside the configured safe zone ROI. Exposure of this colour indicates
+    // the tool has cut beyond the permitted depth and the robot must retract.
+    //
+    // Pipeline:
+    //   1. Crop frame to safe zone ROI — limits work to the relevant area
+    //      and keeps per-frame latency bounded.
+    //   2. Convert ROI from BGR to HSV — separates colour from brightness
+    //      for lighting-robust detection.
+    //   3. Threshold for target hue using two cv::inRange calls combined
+    //      with cv::bitwise_or. Two ranges are required for red because red
+    //      wraps around 0°/180° in OpenCV HSV (H range 0–179).
+    //   4. Count non-zero pixels in the combined mask. A pixel count
+    //      above depthPixelThreshold confirms the layer is exposed.
+    //
+    // Returning DEPTH_EXCEEDED here triggers FREEZE_NOW in GuardianFSM
+    // followed by a retract command via RobotInterlock — distinct from
+    // a standard freeze in that the robot actively retracts rather than
+    // simply halting in place.
+ 
+    if (config_.depthCheckEnabled) {
+ 
+        // Step 1: Crop to safe zone ROI.
+        //
+        // Clamp all coordinates defensively to frame bounds.
+        // Guards against runtime-adjusted ROI values (e.g. dragged via UI)
+        // that transiently extend past the image edges between frames.
+        const int roiX = std::max(0, static_cast<int>(config_.safeZoneXMin));
+        const int roiY = std::max(0, static_cast<int>(config_.safeZoneYMin));
+        const int roiW = std::min(
+            frame.cols - roiX,
+            static_cast<int>(config_.safeZoneXMax - config_.safeZoneXMin));
+        const int roiH = std::min(
+            frame.rows - roiY,
+            static_cast<int>(config_.safeZoneYMax - config_.safeZoneYMin));
+ 
+        // Guard: skip stage if ROI is degenerate (zero or negative dimensions).
+        // Prevents cv::Rect from throwing on a misconfigured or transitional
+        // ROI. The absence of a DEPTH_EXCEEDED result implicitly signals that
+        // the check was bypassed this frame.
+        if (roiW > 0 && roiH > 0) {
+ 
+            // cv::Mat::operator() with a Rect is a zero-copy view — no pixel
+            // data is duplicated. Cheap enough to be safe on every frame.
+            const cv::Mat roi = frame(cv::Rect(roiX, roiY, roiW, roiH));
+ 
+            // Step 2: Convert ROI from BGR to HSV.
+            //
+            // HSV isolates hue from brightness — under variable lab lighting
+            // the same playdough colour can appear significantly darker or
+            // lighter in BGR but its hue remains stable. This makes HSV
+            // thresholding substantially more reliable than BGR thresholding
+            // for a physical demo.
+            cv::Mat hsvRoi;
+            cv::cvtColor(roi, hsvRoi, cv::COLOR_BGR2HSV);
+ 
+            // Step 3: Threshold for target hue range.
+            //
+            // Red wraps around 0°/180° in OpenCV HSV (H: 0–179), so two
+            // separate inRange calls are combined with bitwise_or:
+            //
+            //   mask1 - lower red:  H in [depthHueLower1, depthHueUpper1]
+            //   mask2 - upper red:  H in [depthHueLower2, depthHueUpper2]
+            //
+            // For non-wrapping colours (blue, green, yellow) only mask1 is
+            // needed. Setting depthHueLower2 > depthHueUpper2 in VisionConfig
+            // causes inRange to produce an empty mask2, so the bitwise_or
+            // reduces to mask1 with no code change required.
+            cv::Mat mask1, mask2, combinedMask;
+ 
+            cv::inRange(
+                hsvRoi,
+                cv::Scalar(config_.depthHueLower1,
+                           config_.depthSatMin,
+                           config_.depthValMin),
+                cv::Scalar(config_.depthHueUpper1,
+                           config_.depthSatMax,
+                           config_.depthValMax),
+                mask1);
+ 
+            cv::inRange(
+                hsvRoi,
+                cv::Scalar(config_.depthHueLower2,
+                           config_.depthSatMin,
+                           config_.depthValMin),
+                cv::Scalar(config_.depthHueUpper2,
+                           config_.depthSatMax,
+                           config_.depthValMax),
+                mask2);
+ 
+            // Combine both masks — any pixel matching either hue range is
+            // considered a match. bitwise_or is O(pixels), no allocation.
+            cv::bitwise_or(mask1, mask2, combinedMask);
+ 
+            // Step 4: Count matching pixels.
+            //
+            // countNonZero is O(pixels) with no allocation — safe for
+            // real-time use on every frame.
+            // Compared against depthPixelThreshold to filter noise:
+            // isolated reflections or stray colour patches produce far
+            // fewer matching pixels than genuine layer exposure.
+            const int matchingPixels = cv::countNonZero(combinedMask);
+ 
+            if (matchingPixels >= config_.depthPixelThreshold) {
+                // Forbidden layer confirmed exposed.
+                // Reset inter-frame state so the next safe frame is not
+                // contaminated by stale previousPosition_ or lastTimestamp_
+                // values from before the retract event.
+                hasPrevious_ = false;
+                return makeResult(SafetyState::DEPTH_EXCEEDED);
+            }
         }
     }
 


### PR DESCRIPTION
- Add DEPTH_EXCEEDED to SafetyState enum in Types.hpp
- Add HSV colour threshold fields to VisionConfig (depthHueLower1/2, depthSatMin/Max, depthValMin/Max, depthPixelThreshold, depthCheckEnabled)
- Implement Stage 8 in VisionProcessor::process() using cv::inRange with dual HSV mask for red wrap-around, combined via cv::bitwise_or
- All operations O(pixels) with no heap allocation, latency bounded
- depthCheckEnabled flag allows runtime toggle via UI without recompile
- Follows OCP: existing stages unmodified, new stage self-contained